### PR TITLE
Fix for HR entering NHR conditional

### DIFF
--- a/src/main/java/com/appdynamics/snmp/SNMPTrapSender.java
+++ b/src/main/java/com/appdynamics/snmp/SNMPTrapSender.java
@@ -617,7 +617,7 @@ public class SNMPTrapSender extends CustomNotification
             }
 
             int param = 0;
-            if (!isHRVEvent(args[args.length - 3])) {    //other events
+            if (!isHRVEvent(args[args.length - 1])) {    //other events
 
                 IS_HEALTH_RULE_VIOLATION = false;
 


### PR DESCRIPTION
The last index of the health rule args contains the policy information. The conditional was flagging health rule events as other events, because it was checking the wrong index. Noticed this issue when we updated our controller to 4.0+ and the extension along with it.