### PR TITLE
Make the MIBs more RFC compliant:

### DIFF
--- a/src/main/java/com.appdynamics.extensions.snmp/SNMPDataBuilder.java
+++ b/src/main/java/com.appdynamics.extensions.snmp/SNMPDataBuilder.java
@@ -63,7 +63,12 @@ public class SNMPDataBuilder {
         //get ip addresses and populate ip addresses, machine names
         if(config.isFetchMachineInfoFromApi()){
             populateMachineInfo(violationEvent, nodes, tiers, snmpData);
+        } else {
+            snmpData.setMachines(" ");
+            snmpData.setTiers(" ");
+            snmpData.setIpAddresses(" ");
         }
+
         return snmpData;
     }
 
@@ -147,8 +152,6 @@ public class SNMPDataBuilder {
         snmpData.setTriggeredBy(otherEvent.getEventNotificationName());
         snmpData.setNodes(" ");
         snmpData.setTxns(" ");
-        snmpData.setMachines(" ");
-        snmpData.setTiers(" ");
         snmpData.setEventTime(otherEvent.getEventNotificationTime());
         snmpData.setSeverity(otherEvent.getSeverity());
         snmpData.setType(getTypes(otherEvent));

--- a/src/main/java/com.appdynamics.extensions.snmp/SNMPSender.java
+++ b/src/main/java/com.appdynamics.extensions.snmp/SNMPSender.java
@@ -116,7 +116,15 @@ public class SNMPSender {
                 }
             }
         }
-
+        if (snmpData.getMachines() == null || "".equals(snmpData.getMachines()) || " ".equals(snmpData.getMachines())) {
+            pdu.add(new VariableBinding(new OID(lookUp.getOID("machines")), new OctetString(" ")));
+        }
+        if (snmpData.getTiers() == null || "".equals(snmpData.getTiers()) || " ".equals(snmpData.getTiers())) {
+            pdu.add(new VariableBinding(new OID(lookUp.getOID("tiers")), new OctetString(" ")));
+        }
+        if (snmpData.getIpAddresses() == null || "".equals(snmpData.getIpAddresses()) || " ".equals(snmpData.getIpAddresses())) {
+            pdu.add(new VariableBinding(new OID(lookUp.getOID("ipAddresses")), new OctetString(" ")));
+        }
         Snmp snmp = new Snmp(transport);
         snmp.send(pdu, comTarget);
         snmp.close();
@@ -192,7 +200,7 @@ public class SNMPSender {
     private void sendV3Trap(String host, String port, String trapHost, ADSnmpData snmpData, SnmpV3Configuration config,String trapOid,EngineProperties engineProperties)
             throws IOException, IllegalArgumentException, IllegalAccessException
     {
-        Lookup lookup = new Lookup();
+        Lookup lookUp = new Lookup();
 
         TransportMapping transport = new DefaultUdpTransportMapping();
         transport.listen();
@@ -295,7 +303,7 @@ public class SNMPSender {
                     Object snmpVal = new OctetString(field.get(snmpData).toString());
 
                     if (!(snmpVal.equals(" ") || snmpVal.equals(""))) {
-                        pdu.add(new VariableBinding(new OID(lookup.getOID(field.getName())), new OctetString(snmpVal.toString())));
+                        pdu.add(new VariableBinding(new OID(lookUp.getOID(field.getName())), new OctetString(snmpVal.toString())));
                     }
                 } catch (Throwable ex) {
                     logger.error("Error reading snmp data field:", ex);

--- a/src/main/java/com.appdynamics.extensions.snmp/SNMPSender.java
+++ b/src/main/java/com.appdynamics.extensions.snmp/SNMPSender.java
@@ -102,6 +102,16 @@ public class SNMPSender {
         pdu.add(new VariableBinding(SnmpConstants.snmpTrapOID, new OID(trapOid)));
         pdu.add(new VariableBinding(SnmpConstants.snmpTrapAddress, new IpAddress(trapHost)));
 
+        if (snmpData.getMachines() == null || "".equals(snmpData.getMachines()) || " ".equals(snmpData.getMachines())) {
+            snmpData.setMachines(" ");
+        }
+        if (snmpData.getTiers() == null || "".equals(snmpData.getTiers()) || " ".equals(snmpData.getTiers())) {
+            snmpData.setTiers(" ");
+        }
+        if (snmpData.getIpAddresses() == null || "".equals(snmpData.getIpAddresses()) || " ".equals(snmpData.getIpAddresses())) {
+            snmpData.setIpAddresses(" ");
+        }
+
         for (Field field : snmpData.getClass().getDeclaredFields())
         {
             if(field.get(snmpData) != null) {
@@ -116,15 +126,7 @@ public class SNMPSender {
                 }
             }
         }
-        if (snmpData.getMachines() == null || "".equals(snmpData.getMachines()) || " ".equals(snmpData.getMachines())) {
-            pdu.add(new VariableBinding(new OID(lookUp.getOID("machines")), new OctetString(" ")));
-        }
-        if (snmpData.getTiers() == null || "".equals(snmpData.getTiers()) || " ".equals(snmpData.getTiers())) {
-            pdu.add(new VariableBinding(new OID(lookUp.getOID("tiers")), new OctetString(" ")));
-        }
-        if (snmpData.getIpAddresses() == null || "".equals(snmpData.getIpAddresses()) || " ".equals(snmpData.getIpAddresses())) {
-            pdu.add(new VariableBinding(new OID(lookUp.getOID("ipAddresses")), new OctetString(" ")));
-        }
+
         Snmp snmp = new Snmp(transport);
         snmp.send(pdu, comTarget);
         snmp.close();

--- a/src/main/resources/mib/APPD-CTLR-MIB-v1.mib
+++ b/src/main/resources/mib/APPD-CTLR-MIB-v1.mib
@@ -18,26 +18,22 @@ IMPORTS
 	snmpTrapAddress
 		FROM SNMP-COMMUNITY-MIB;
 
-appDynamics MODULE-IDENTITY
-	LAST-UPDATED "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
+appdMIB MODULE-IDENTITY
+	LAST-UPDATED "201701030000Z"    -- January 3, 2016 12:00:00 AM
 	ORGANIZATION "AppDynamics Inc"
 	CONTACT-INFO
 		"Not telling"
 	DESCRIPTION
 		"AppDynamics Trap MIB"
-	REVISION "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
+	REVISION "201701030000Z"    -- January 3, 2016 12:00:00 AM
 	DESCRIPTION
 		"First Release - Only One OID"
-	-- 1.3.6.1.4.1.40684
-	::= { enterprises 40684 }
-
-appDynamics1 OBJECT IDENTIFIER
-	-- 1.3.6.1.4.1.40684.1
-	::= { appDynamics 1 }
-
-appdMIB OBJECT IDENTIFIER
 	-- 1.3.6.1.4.1.40684.1.1
 	::= { appDynamics1 1 }
+
+appDynamics OBJECT IDENTIFIER ::= { enterprises 40684}
+
+appDynamics1 OBJECT IDENTIFIER ::= { appDynamics 1 }
 
 appd OBJECT IDENTIFIER
 	-- 1.3.6.1.4.1.40684.1.1.1

--- a/src/main/resources/mib/APPD-CTLR-MIB-v1.mib
+++ b/src/main/resources/mib/APPD-CTLR-MIB-v1.mib
@@ -11,25 +11,33 @@ IMPORTS
 		FROM SNMPv2-TC
 	OBJECT-GROUP,
 	NOTIFICATION-GROUP
-		FROM SNMPv2-CONF;
+		FROM SNMPv2-CONF
+	sysUpTime,
+	snmpTrapOID
+		FROM SNMPv2-MIB
+	snmpTrapAddress
+		FROM SNMP-COMMUNITY-MIB;
 
-AppDynamics OBJECT IDENTIFIER ::= { enterprises 40684}
-
-AppDynamics1 OBJECT IDENTIFIER ::= { AppDynamics 1 }
-
-appdMIB MODULE-IDENTITY
-	LAST-UPDATED "201209010000Z"	-- Sep 1, 2012 12:00:00 AM
+appDynamics MODULE-IDENTITY
+	LAST-UPDATED "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
 	ORGANIZATION "AppDynamics Inc"
 	CONTACT-INFO
 		"Not telling"
 	DESCRIPTION
 		"AppDynamics Trap MIB"
-	REVISION "201209010000Z"	-- Sep 1, 2012 12:00:00 AM
+	REVISION "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
 	DESCRIPTION
 		"First Release - Only One OID"
-	-- 1.3.6.1.4.1.40684.1.1
-	::= { AppDynamics1 1 }
+	-- 1.3.6.1.4.1.40684
+	::= { enterprises 40684 }
 
+appDynamics1 OBJECT IDENTIFIER
+	-- 1.3.6.1.4.1.40684.1
+	::= { appDynamics 1 }
+
+appdMIB OBJECT IDENTIFIER
+	-- 1.3.6.1.4.1.40684.1.1
+	::= { appDynamics1 1 }
 
 appd OBJECT IDENTIFIER
 	-- 1.3.6.1.4.1.40684.1.1.1
@@ -86,6 +94,9 @@ appdEventObjects OBJECT-GROUP
 
 event NOTIFICATION-TYPE
 	OBJECTS {
+		sysUpTime,
+		snmpTrapOID,
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,

--- a/src/main/resources/mib/APPD-CTLR-MIB-v2.mib
+++ b/src/main/resources/mib/APPD-CTLR-MIB-v2.mib
@@ -15,28 +15,22 @@ IMPORTS
 	snmpTrapAddress
 		FROM SNMP-COMMUNITY-MIB;
 
-
-appDynamics MODULE-IDENTITY
-	LAST-UPDATED "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
+appdMIB MODULE-IDENTITY
+	LAST-UPDATED "201701030000Z"    -- January 3, 2016 12:00:00 AM
 	ORGANIZATION "AppDynamics Inc"
 	CONTACT-INFO
 		"Not telling"
 	DESCRIPTION
 		"AppDynamics Trap MIB"
-	REVISION "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
+	REVISION "201701030000Z"    -- January 3, 2016 12:00:00 AM
 	DESCRIPTION
 		"Second Release - Three OID's"
-	-- 1.3.6.1.4.1.40684
-	::= { enterprises 40684 }
-
-appDynamics1 OBJECT IDENTIFIER
-	-- 1.3.6.1.4.1.40684.1
-	::= { appDynamics 1 }
-
-appdMIB OBJECT IDENTIFIER
 	-- 1.3.6.1.4.1.40684.1.1
 	::= { appDynamics1 1 }
 
+appDynamics OBJECT IDENTIFIER ::= { enterprises 40684}
+
+appDynamics1 OBJECT IDENTIFIER ::= { appDynamics 1 }
 
 appd OBJECT IDENTIFIER
 	-- 1.3.6.1.4.1.40684.1.1.1
@@ -95,6 +89,7 @@ appdEventObjects OBJECT-GROUP
 
 policyOpen NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,

--- a/src/main/resources/mib/APPD-CTLR-MIB-v2.mib
+++ b/src/main/resources/mib/APPD-CTLR-MIB-v2.mib
@@ -147,8 +147,6 @@ nonPolicyEvent NOTIFICATION-TYPE
 		triggeredBy,
 		nodes,
 		txns,
-		machines,
-		tiers,
 		eventTime,
 		severity,
 		type,
@@ -157,7 +155,6 @@ nonPolicyEvent NOTIFICATION-TYPE
 		link,
 		tag,
                 eventType,
-                ipAddresses,
                 incidentId,
                  accountId}
 	STATUS  current

--- a/src/main/resources/mib/APPD-CTLR-MIB-v2.mib
+++ b/src/main/resources/mib/APPD-CTLR-MIB-v2.mib
@@ -11,24 +11,31 @@ IMPORTS
 		FROM SNMPv2-TC
 	OBJECT-GROUP,
 	NOTIFICATION-GROUP
-		FROM SNMPv2-CONF;
+		FROM SNMPv2-CONF
+	snmpTrapAddress
+		FROM SNMP-COMMUNITY-MIB;
 
-AppDynamics OBJECT IDENTIFIER ::= { enterprises 40684}
 
-AppDynamics1 OBJECT IDENTIFIER ::= { AppDynamics 1 }
-
-appdMIB MODULE-IDENTITY
-	LAST-UPDATED "201209010000Z"	-- Sep 1, 2012 12:00:00 AM
+appDynamics MODULE-IDENTITY
+	LAST-UPDATED "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
 	ORGANIZATION "AppDynamics Inc"
 	CONTACT-INFO
 		"Not telling"
 	DESCRIPTION
 		"AppDynamics Trap MIB"
-	REVISION "201209010000Z"	-- Sep 1, 2012 12:00:00 AM
+	REVISION "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
 	DESCRIPTION
 		"Second Release - Three OID's"
+	-- 1.3.6.1.4.1.40684
+	::= { enterprises 40684 }
+
+appDynamics1 OBJECT IDENTIFIER
+	-- 1.3.6.1.4.1.40684.1
+	::= { appDynamics 1 }
+
+appdMIB OBJECT IDENTIFIER
 	-- 1.3.6.1.4.1.40684.1.1
-	::= { AppDynamics1 1 }
+	::= { appDynamics1 1 }
 
 
 appd OBJECT IDENTIFIER
@@ -113,6 +120,7 @@ policyOpen NOTIFICATION-TYPE
 
 policyClosed NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,
@@ -139,6 +147,7 @@ policyClosed NOTIFICATION-TYPE
 
 nonPolicyEvent NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,

--- a/src/main/resources/mib/APPD-CTLR-MIB-v3.mib
+++ b/src/main/resources/mib/APPD-CTLR-MIB-v3.mib
@@ -260,8 +260,6 @@ nonPolicyEvent NOTIFICATION-TYPE
 		triggeredBy,
 		nodes,
 		txns,
-		machines,
-		tiers,
 		eventTime,
 		severity,
 		type,
@@ -270,7 +268,6 @@ nonPolicyEvent NOTIFICATION-TYPE
 		link,
 		tag,
                 eventType,
-                ipAddresses,
                 incidentId,
                  accountId}
 	STATUS  current

--- a/src/main/resources/mib/APPD-CTLR-MIB-v3.mib
+++ b/src/main/resources/mib/APPD-CTLR-MIB-v3.mib
@@ -11,25 +11,30 @@ IMPORTS
 		FROM SNMPv2-TC
 	OBJECT-GROUP,
 	NOTIFICATION-GROUP
-		FROM SNMPv2-CONF;
+		FROM SNMPv2-CONF
+	snmpTrapAddress
+		FROM SNMP-COMMUNITY-MIB;
 
-AppDynamics OBJECT IDENTIFIER ::= { enterprises 40684}
-
-AppDynamics1 OBJECT IDENTIFIER ::= { AppDynamics 1 }
-
-appdMIB MODULE-IDENTITY
-	LAST-UPDATED "201209010000Z"	-- Sep 1, 2012 12:00:00 AM
+appDynamics MODULE-IDENTITY
+	LAST-UPDATED "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
 	ORGANIZATION "AppDynamics Inc"
 	CONTACT-INFO
 		"Not telling"
 	DESCRIPTION
 		"AppDynamics Trap MIB"
-	REVISION "201209010000Z"	-- Sep 1, 2012 12:00:00 AM
+	REVISION "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
 	DESCRIPTION
 		"Second Release - Six OID's"
-	-- 1.3.6.1.4.1.40684.1.1
-	::= { AppDynamics1 1 }
+	-- 1.3.6.1.4.1.40684
+	::= { enterprises 40684 }
 
+appDynamics1 OBJECT IDENTIFIER
+	-- 1.3.6.1.4.1.40684.1
+	::= { appDynamics 1 }
+
+appdMIB OBJECT IDENTIFIER
+	-- 1.3.6.1.4.1.40684.1.1
+	::= { appDynamics1 1 }
 
 appd OBJECT IDENTIFIER
 	-- 1.3.6.1.4.1.40684.1.1.1
@@ -96,6 +101,7 @@ appdEventObjects OBJECT-GROUP
 
 policyOpenWarning NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,
@@ -121,6 +127,7 @@ policyOpenWarning NOTIFICATION-TYPE
 
 policyOpenCritical NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,
@@ -146,6 +153,7 @@ policyOpenCritical NOTIFICATION-TYPE
 
 policyUpgraded NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,
@@ -171,6 +179,7 @@ policyUpgraded NOTIFICATION-TYPE
 
 policyDowngraded NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,
@@ -196,6 +205,7 @@ policyDowngraded NOTIFICATION-TYPE
 
 policyClosedWarning NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,
@@ -223,6 +233,7 @@ policyClosedWarning NOTIFICATION-TYPE
 
 policyClosedCritical NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,
@@ -248,6 +259,7 @@ policyClosedCritical NOTIFICATION-TYPE
 
 nonPolicyEvent NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,
@@ -273,6 +285,7 @@ nonPolicyEvent NOTIFICATION-TYPE
 
 policyCancelledWarning NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,
@@ -298,6 +311,7 @@ policyCancelledWarning NOTIFICATION-TYPE
 
 policyCancelledCritical NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,
@@ -323,6 +337,7 @@ policyCancelledCritical NOTIFICATION-TYPE
 
 policyContinuesWarning NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,
@@ -349,6 +364,7 @@ policyContinuesWarning NOTIFICATION-TYPE
 
 policyContinuesCritical NOTIFICATION-TYPE
 	OBJECTS {
+		snmpTrapAddress,
 		application,
 		triggeredBy,
 		nodes,

--- a/src/main/resources/mib/APPD-CTLR-MIB-v3.mib
+++ b/src/main/resources/mib/APPD-CTLR-MIB-v3.mib
@@ -15,26 +15,22 @@ IMPORTS
 	snmpTrapAddress
 		FROM SNMP-COMMUNITY-MIB;
 
-appDynamics MODULE-IDENTITY
-	LAST-UPDATED "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
+appdMIB MODULE-IDENTITY
+	LAST-UPDATED "201701030000Z"    -- January 3, 2016 12:00:00 AM
 	ORGANIZATION "AppDynamics Inc"
 	CONTACT-INFO
 		"Not telling"
 	DESCRIPTION
 		"AppDynamics Trap MIB"
-	REVISION "201612290000Z"	-- Dec 29, 2016 12:00:00 AM
+	REVISION "201701030000Z"    -- January 3, 2016 12:00:00 AM
 	DESCRIPTION
 		"Second Release - Six OID's"
-	-- 1.3.6.1.4.1.40684
-	::= { enterprises 40684 }
-
-appDynamics1 OBJECT IDENTIFIER
-	-- 1.3.6.1.4.1.40684.1
-	::= { appDynamics 1 }
-
-appdMIB OBJECT IDENTIFIER
 	-- 1.3.6.1.4.1.40684.1.1
 	::= { appDynamics1 1 }
+
+appDynamics OBJECT IDENTIFIER ::= { enterprises 40684}
+
+appDynamics1 OBJECT IDENTIFIER ::= { appDynamics 1 }
 
 appd OBJECT IDENTIFIER
 	-- 1.3.6.1.4.1.40684.1.1.1


### PR DESCRIPTION
 - The MODULE-IDENTITY must be the first declaration in the MIB.
 - ASN.1 identifiers must begin with a lowercase letter.
 - The SNMPSender class adds sysUpTime, snmpTrapOID, and snmpTrapAddress
   objects to every trap. Import those objects, and include them in the
NOTIFICATION-TYPE object declarations.
 - Any objects defined in a NOTIFICATION-TYPE macro's OBJECTS clause are copied into the variable bindings of an instance of that notification, in order (RFC 3416 section 4.2.6). Don't include objects that are never added to the PDU for nonPolicyEvent events, and ensure that the machines, tiers, and ipAddresses objects are present even if they are empty/null.