### PR TITLE
Miscellaneous Fixups

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -47,12 +47,12 @@ snmpVersion: 2
 #policies for snmp v3.
 #####################################################################################
 #snmpV3Configuration:
-# securityLevel:
-# username: ""
-# password: ""
-# authProtocol: ""
-# privProtocol: ""
-# privProtocolPassword: ""
+#  securityLevel:
+#  username: ""
+#  password: ""
+#  authProtocol: ""
+#  privProtocol: ""
+#  privProtocolPassword: ""
 
 ######SNMP Trap information end##############
 

--- a/src/main/java/com.appdynamics.extensions.snmp/SNMPDataBuilder.java
+++ b/src/main/java/com.appdynamics.extensions.snmp/SNMPDataBuilder.java
@@ -158,7 +158,7 @@ public class SNMPDataBuilder {
             snmpData.setLink(CommonUtils.getAlertUrl(otherEvent));
         }
         snmpData.setTag(otherEvent.getTag());
-        snmpData.setEventType("NON-POLICY-EVENT");
+        snmpData.setEventType("NON_POLICY_EVENT");
         snmpData.setIncidentId(otherEvent.getEventNotificationId());
         snmpData.setAccountId(CommonUtils.cleanUpAccountInfo(otherEvent.getAccountId()));
         return snmpData;

--- a/src/main/java/com.appdynamics.extensions.snmp/SnmpTrapAlertExtension.java
+++ b/src/main/java/com.appdynamics.extensions.snmp/SnmpTrapAlertExtension.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 public class SnmpTrapAlertExtension {
 
     public static final String MULTI_TENANCY = "appDynamics.controller.multiTenant";
+    private static final String TRAP_OID_NOTIFICATIONS = "1.3.6.1.4.1.40684.1.1.1.500";
     private static final String TRAP_OID_01 = "1.3.6.1.4.1.40684.1.1.1.500.1";
     private static final String TRAP_OID_02 = "1.3.6.1.4.1.40684.1.1.1.500.2";
     private static final String TRAP_OID_03 = "1.3.6.1.4.1.40684.1.1.1.500.3";
@@ -122,7 +123,7 @@ public class SnmpTrapAlertExtension {
         if(event instanceof OtherEvent) {
             switch (config.getMibVersion()) {
                 case 1:
-                    TRAP_OID = TRAP_OID_01;
+                    TRAP_OID = TRAP_OID_NOTIFICATIONS;
                     break;
                 case 2:
                     TRAP_OID = TRAP_OID_03;
@@ -138,7 +139,7 @@ public class SnmpTrapAlertExtension {
         String eventType = violationEvent.getEventType();
         switch (config.getMibVersion()) {
             case 1:
-                TRAP_OID = TRAP_OID_01;
+                TRAP_OID = TRAP_OID_NOTIFICATIONS;
                 break;
 
             case 2:

--- a/src/main/java/com.appdynamics.extensions.snmp/SnmpTrapAlertExtension.java
+++ b/src/main/java/com.appdynamics.extensions.snmp/SnmpTrapAlertExtension.java
@@ -118,12 +118,24 @@ public class SnmpTrapAlertExtension {
      *
      */
     private String getOID(Event event) {
-        if(event instanceof OtherEvent){
-            return TRAP_OID_07;
+        String TRAP_OID = TRAP_OID_01;
+        if(event instanceof OtherEvent) {
+            switch (config.getMibVersion()) {
+                case 1:
+                    TRAP_OID = TRAP_OID_01;
+                    break;
+                case 2:
+                    TRAP_OID = TRAP_OID_03;
+                    break;
+                case 3:
+                    TRAP_OID = TRAP_OID_07;
+                    break;
+            }
+            return TRAP_OID;
         }
+
         HealthRuleViolationEvent violationEvent = (HealthRuleViolationEvent) event;
         String eventType = violationEvent.getEventType();
-        String TRAP_OID = TRAP_OID_01;
         switch (config.getMibVersion()) {
             case 1:
                 TRAP_OID = TRAP_OID_01;


### PR DESCRIPTION
Change NON-POLICY-EVENT to NON_POLICY_EVENT to be consistent with other eventType labels and with SnmpTrapAlertExtension.getOID.
Don't send undefined trap OID for SNMPv1 or SNMPv2.
Add a space to each line in the snmpV3Configuration block in config.yml, so that YmlReader can parse it correctly when uncommented.