### PR TITLE
Time tick bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.appdynamics.extensions</groupId>
     <artifactId>snmp-trap-alert</artifactId>
-    <version>5.3.1</version>
+    <version>5.3.2</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/appdynamics/extensions/snmp/CommonUtils.java
+++ b/src/main/java/com/appdynamics/extensions/snmp/CommonUtils.java
@@ -14,6 +14,7 @@ import com.appdynamics.extensions.alerts.customevents.OtherEvent;
 import com.google.common.base.Strings;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.log4j.Logger;
+import org.snmp4j.smi.TimeTicks;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -77,5 +78,21 @@ public class CommonUtils {
             logger.error("Unsupported platform " + SystemUtils.OS_NAME + ".");
         }
         return _sysUpTime;
+    }
+
+    public static TimeTicks getTimeTicks(long upTimeInMs) {
+        TimeTicks sysUpTime = new TimeTicks();
+        try {
+            /*
+              Timeticks takes only unsigned int 32-bit values. 4294967295L
+              will rollover after 496 days and typecasting it to (int) would return -ve. So absolute
+             */
+            int upTime = (int)upTimeInMs;
+            sysUpTime.fromMilliseconds(Math.abs(upTime));
+        }
+        catch(IllegalArgumentException e){
+            logger.error("Cannot convert to timeticks for value " + upTimeInMs,e);
+        }
+        return sysUpTime;
     }
 }

--- a/src/main/java/com/appdynamics/extensions/snmp/SNMPSender.java
+++ b/src/main/java/com/appdynamics/extensions/snmp/SNMPSender.java
@@ -103,8 +103,7 @@ public class SNMPSender {
         comTarget.setRetries(2);
         comTarget.setTimeout(5000);
 
-        TimeTicks sysUpTime = new TimeTicks();
-        sysUpTime.fromMilliseconds(getSysUptime());
+        TimeTicks sysUpTime = getTimeTicks();
 
         PDUv1 pdu = new PDUv1();
         pdu.setType(PDU.V1TRAP);
@@ -174,9 +173,8 @@ public class SNMPSender {
         comTarget.setRetries(2);
         comTarget.setTimeout(5000);
 
-        long upTimeInMs = getSysUptime();
+        TimeTicks sysUpTime = getTimeTicks();
 
-        TimeTicks sysUpTime = getTimeTicks(upTimeInMs);
         PDU pdu = new PDU();
         pdu.add(new VariableBinding(SnmpConstants.sysUpTime,  sysUpTime));
         pdu.add(new VariableBinding(SnmpConstants.snmpTrapOID, new OID(trapOid)));
@@ -205,6 +203,10 @@ public class SNMPSender {
         snmp.close();
     }
 
+    private TimeTicks getTimeTicks() {
+        long upTimeInMs = getSysUptime();
+        return CommonUtils.getTimeTicks(upTimeInMs);
+    }
 
 
     /**
@@ -312,8 +314,7 @@ public class SNMPSender {
         usrTarget.setSecurityName(new OctetString(config.getUsername()));
         usrTarget.setTimeout(5000);
 
-        TimeTicks sysUpTime = new TimeTicks();
-        sysUpTime.fromMilliseconds(getSysUptime());
+        TimeTicks sysUpTime = getTimeTicks();
 
         PDU pdu = new ScopedPDU();
         pdu.setType(PDU.NOTIFICATION);

--- a/src/main/java/com/appdynamics/extensions/snmp/SNMPSender.java
+++ b/src/main/java/com/appdynamics/extensions/snmp/SNMPSender.java
@@ -206,12 +206,15 @@ public class SNMPSender {
         TimeTicks sysUpTime = new TimeTicks();
         long upTimeInMs = getSysUptime();
         try {
-            sysUpTime.fromMilliseconds(upTimeInMs);
+            /*
+              Timeticks takes only unsigned int 32-bit values. 4294967295L
+              will rollover after 496 days and typecasting it to (int) would return -ve. So absolute
+             */
+            int upTime = (int)upTimeInMs;
+            sysUpTime.fromMilliseconds(Math.abs(upTime));
         }
         catch(IllegalArgumentException e){
-            if(upTimeInMs > 4294967295L){ //32bit unsigned only
-                sysUpTime.fromMilliseconds((int)upTimeInMs);
-            }
+            logger.error("Cannot convert to timeticks for value " + upTimeInMs,e);
         }
         return sysUpTime;
     }

--- a/src/main/java/com/appdynamics/extensions/snmp/SNMPSender.java
+++ b/src/main/java/com/appdynamics/extensions/snmp/SNMPSender.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.List;
 
 import static com.appdynamics.extensions.snmp.CommonUtils.getSysUptime;
+import static com.appdynamics.extensions.snmp.CommonUtils.getTimeTicks;
 
 public class SNMPSender {
 
@@ -173,7 +174,9 @@ public class SNMPSender {
         comTarget.setRetries(2);
         comTarget.setTimeout(5000);
 
-        TimeTicks sysUpTime = getTimeTicks();
+        long upTimeInMs = getSysUptime();
+
+        TimeTicks sysUpTime = getTimeTicks(upTimeInMs);
         PDU pdu = new PDU();
         pdu.add(new VariableBinding(SnmpConstants.sysUpTime,  sysUpTime));
         pdu.add(new VariableBinding(SnmpConstants.snmpTrapOID, new OID(trapOid)));
@@ -202,22 +205,7 @@ public class SNMPSender {
         snmp.close();
     }
 
-    private TimeTicks getTimeTicks() {
-        TimeTicks sysUpTime = new TimeTicks();
-        long upTimeInMs = getSysUptime();
-        try {
-            /*
-              Timeticks takes only unsigned int 32-bit values. 4294967295L
-              will rollover after 496 days and typecasting it to (int) would return -ve. So absolute
-             */
-            int upTime = (int)upTimeInMs;
-            sysUpTime.fromMilliseconds(Math.abs(upTime));
-        }
-        catch(IllegalArgumentException e){
-            logger.error("Cannot convert to timeticks for value " + upTimeInMs,e);
-        }
-        return sysUpTime;
-    }
+
 
     /**
      * Sends v3 Traps

--- a/src/test/java/com/appdynamics/extensions/TimeTicksTest.java
+++ b/src/test/java/com/appdynamics/extensions/TimeTicksTest.java
@@ -1,0 +1,25 @@
+package com.appdynamics.extensions;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.snmp4j.smi.TimeTicks;
+
+import static com.appdynamics.extensions.snmp.CommonUtils.getSysUptime;
+
+public class TimeTicksTest {
+
+    @Test
+    public void whenTimeMoreThanIntegerMaxThenTheErrorShouldBeHandled(){
+        TimeTicks timeTicks = getTimeTicks(42234242394967295L);
+        Assert.assertTrue(timeTicks.getValue() != 0);
+    }
+
+
+    private TimeTicks getTimeTicks(long upTimeInMs) {
+        TimeTicks sysUpTime = new TimeTicks();
+        int upTime = (int)upTimeInMs;
+        sysUpTime.fromMilliseconds(Math.abs(upTime));
+        return sysUpTime;
+    }
+
+}

--- a/src/test/java/com/appdynamics/extensions/TimeTicksTest.java
+++ b/src/test/java/com/appdynamics/extensions/TimeTicksTest.java
@@ -1,5 +1,6 @@
 package com.appdynamics.extensions;
 
+import com.appdynamics.extensions.snmp.CommonUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.snmp4j.smi.TimeTicks;
@@ -10,16 +11,11 @@ public class TimeTicksTest {
 
     @Test
     public void whenTimeMoreThanIntegerMaxThenTheErrorShouldBeHandled(){
-        TimeTicks timeTicks = getTimeTicks(42234242394967295L);
+        TimeTicks timeTicks = CommonUtils.getTimeTicks(42234242394967295L);
         Assert.assertTrue(timeTicks.getValue() != 0);
     }
 
 
-    private TimeTicks getTimeTicks(long upTimeInMs) {
-        TimeTicks sysUpTime = new TimeTicks();
-        int upTime = (int)upTimeInMs;
-        sysUpTime.fromMilliseconds(Math.abs(upTime));
-        return sysUpTime;
-    }
+
 
 }


### PR DESCRIPTION
Issue here was that TimeTicks object from SNMP cannot hold more than unsigned int values. Because of that when typecasting to int, it was rolling over and the number was becoming negative which the library complained about. 